### PR TITLE
GitHub Action to automate build/release of BMSL CLIs 

### DIFF
--- a/.github/workflows/windows-linux-build-release.yml
+++ b/.github/workflows/windows-linux-build-release.yml
@@ -1,0 +1,82 @@
+
+
+name: Build on Windows and Linux and create a release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on:  ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+            exe_name: "distribution"
+            source_path: "cli/distribution"
+            test_cmd: .\distribution.exe --version
+          - os: ubuntu-latest
+            exe_name: "distribution"
+            source_path: "cli/distribution"
+            test_cmd: ./distribution --version
+
+    steps:
+      - uses: actions/checkout@v4
+          
+      - name: Verify gfortran
+        run: gfortran --version
+
+      - name: Install dependencies
+        run: |
+          cd ..
+          git clone https://github.com/benRenard/miniDMSL.git miniDMSL 
+
+      - name: Call make
+        run: |
+          cd ${{ matrix.source_path }}
+          make
+
+      - name: Test executable
+        run: |
+          cd ${{ matrix.source_path }}
+          ${{ matrix.test_cmd }}
+
+      - name: Rename artifact (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          cd ${{ matrix.source_path }}
+          mv ${{ matrix.exe_name }} ${{ matrix.exe_name }}-${VERSION}-linux
+
+      - name: Rename artifact (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $version = "${env:GITHUB_REF}".Replace("refs/tags/", "")
+          cd ${{ matrix.source_path }}
+          Rename-Item ${{ matrix.exe_name }}.exe "${{ matrix.exe_name }}-$version-windows.exe"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.exe_name }}-${{ matrix.os }}
+          path: ${{ matrix.source_path }}/${{ matrix.exe_name }}-*
+          
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: BMSL CLIs ${{ github.ref_name }}
+          generate_release_notes: true
+          files: artifacts/**/*
+

--- a/cli/distribution/makefile
+++ b/cli/distribution/makefile
@@ -5,7 +5,7 @@
 
 # Define the Fortran Compiler and its options
 FC  = gfortran
-FLAGS = -fcheck=all -Wall -O3 # DEBUG: -fcheck=all -Wall -g -O0
+FLAGS = -fcheck=all -Wall -O3 -static # DEBUG: -fcheck=all -Wall -g -O0
 
 # Define directories
 DMSL_DIR = ../../../miniDMSL/src/


### PR DESCRIPTION
I've adapted the GitHub Action used for BaM to automate the process of building and release the distribution CLI. 

I've adapted it so it should be easy to add other CLIs in the process. By duplicating the two sections in the `jobs > build > strategy > matrix > include` and modifying the variables defined there, it should work but I haven't tested it yet. 

I've also added the static flag in the makefile of the distribution CLI.

By the way, in the case you decide to make modification to any action or create new actions that rely on publishing new tags and/or creating release I strongly advice you to create a fork so it doesn't affect the original repo (it can get pretty messy!).

Let me know what you think. If you think it is worth testing first that it works for building/releasing multiple CLIs, let me know, I'll do it before you merge this PR. 
